### PR TITLE
Delay init until Plugins Loaded

### DIFF
--- a/wp-minions.php
+++ b/wp-minions.php
@@ -49,8 +49,10 @@ add_action( 'plugins_loaded', function() {
 	}
 });
 
-// Init
-if ( ! defined( 'PHPUNIT_RUNNER' ) ) {
-	wp_async_task_init();
-}
+add_action( 'plugins_loaded', function() {
+	// Init
+	if ( ! defined( 'PHPUNIT_RUNNER' ) ) {
+		wp_async_task_init();
+	}
+}, 9 );
 


### PR DESCRIPTION
I'm using WP Minions with a custom Client and Worker implementation (AWS SQS) and ran into difficulties with the order of loading. `Plugin::enable()` loads the client and worker objects immediately, but if this plugin is loaded before the plugin containing the custom classes, PHP crashes because it can't find the classes registered as the client and worker. Delaying the running of `wp_async_task_init()` until `plugins_loaded` fixes this problem.